### PR TITLE
improve theme shell

### DIFF
--- a/passion.zsh-theme
+++ b/passion.zsh-theme
@@ -103,7 +103,7 @@ output_command_execute_after() {
     fi
 
     # cmd
-    local cmd="${$(fc -l | tail -1)#*  }";
+    local cmd="${$(fc -ln | tail -1)#*  }";
     local color_cmd="";
     if $1;
     then


### PR DESCRIPTION
passion.zsh-theme: line#106
`local cmd="${$(fc -l | tail -1)#*  }"`

will return line number, and I think it's should be optimized
![image](https://user-images.githubusercontent.com/59912384/177506492-08da0131-b3fe-49a7-9ab3-88002383229e.png)


add `-n` flag to `fc` command to ignore the line number.

`local cmd="${$(fc -ln | tail -1)#*  }"`